### PR TITLE
feat: add offline caching for encrypted API responses

### DIFF
--- a/phase/network/network.go
+++ b/phase/network/network.go
@@ -200,6 +200,62 @@ func FetchPhaseUser(tokenType, appToken, host string) (*http.Response, error) {
 	return resp, nil
 }
 
+// FetchPhaseUserRaw returns the raw JSON bytes from the user/tokens endpoint.
+func FetchPhaseUserRaw(tokenType, appToken, host string) ([]byte, error) {
+	url := fmt.Sprintf("%s/service/secrets/tokens/", host)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = ConstructHTTPHeaders(tokenType, appToken)
+	return makeRequest(req)
+}
+
+// FetchPhaseSecretsRaw returns the raw JSON bytes from the secrets endpoint.
+func FetchPhaseSecretsRaw(tokenType, appToken, environmentID, host, path, keyDigest string) ([]byte, error) {
+	url := fmt.Sprintf("%s/service/secrets/", host)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = ConstructHTTPHeaders(tokenType, appToken)
+	req.Header.Set("Environment", environmentID)
+	if path != "" {
+		req.Header.Set("Path", path)
+	}
+	if keyDigest != "" {
+		req.Header.Set("KeyDigest", keyDigest)
+	}
+	return makeRequest(req)
+}
+
+// FetchPhaseSecretsWithDynamicRaw returns the raw JSON bytes from the secrets endpoint with dynamic secret support.
+func FetchPhaseSecretsWithDynamicRaw(tokenType, appToken, envID, host, path, keyDigest string, dynamic, lease bool, leaseTTL *int) ([]byte, error) {
+	reqURL := fmt.Sprintf("%s/service/secrets/", host)
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = ConstructHTTPHeaders(tokenType, appToken)
+	req.Header.Set("Environment", envID)
+	if path != "" {
+		req.Header.Set("Path", path)
+	}
+	if keyDigest != "" {
+		req.Header.Set("KeyDigest", keyDigest)
+	}
+	if dynamic {
+		req.Header.Set("dynamic", "true")
+	}
+	if lease {
+		req.Header.Set("lease", "true")
+	}
+	if leaseTTL != nil {
+		req.Header.Set("lease-ttl", fmt.Sprintf("%d", *leaseTTL))
+	}
+	return makeRequest(req)
+}
+
 func FetchAppKey(tokenType, appToken, host string) (string, error) {
 	client := getHTTPClient()
 	url := fmt.Sprintf("%s/service/secrets/tokens/", host)

--- a/phase/network/network.go
+++ b/phase/network/network.go
@@ -202,8 +202,8 @@ func FetchPhaseUser(tokenType, appToken, host string) (*http.Response, error) {
 
 // FetchPhaseUserRaw returns the raw JSON bytes from the user/tokens endpoint.
 func FetchPhaseUserRaw(tokenType, appToken, host string) ([]byte, error) {
-	url := fmt.Sprintf("%s/service/secrets/tokens/", host)
-	req, err := http.NewRequest("GET", url, nil)
+	reqURL := fmt.Sprintf("%s/service/secrets/tokens/", host)
+	req, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -284,38 +284,14 @@ func FetchAppKey(tokenType, appToken, host string) (string, error) {
 }
 
 func FetchPhaseSecrets(tokenType, appToken, environmentID, host, path, keyDigest string) ([]map[string]interface{}, error) {
-	client := getHTTPClient()
-	url := fmt.Sprintf("%s/service/secrets/", host)
-
-	req, err := http.NewRequest("GET", url, nil)
+	body, err := FetchPhaseSecretsRaw(tokenType, appToken, environmentID, host, path, keyDigest)
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header = ConstructHTTPHeaders(tokenType, appToken)
-	req.Header.Set("Environment", environmentID)
-	if path != "" {
-		req.Header.Set("Path", path)
-	}
-	if keyDigest != "" {
-		req.Header.Set("KeyDigest", keyDigest)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, wrapTransportError(err)
-	}
-	defer resp.Body.Close()
-
-	if err := handleHTTPResponse(resp); err != nil {
-		return nil, err
-	}
-
 	var secrets []map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&secrets); err != nil {
+	if err := json.Unmarshal(body, &secrets); err != nil {
 		return nil, fmt.Errorf("failed to decode JSON response: %v", err)
 	}
-
 	return secrets, nil
 }
 
@@ -436,35 +412,10 @@ func DeletePhaseSecrets(tokenType, appToken, environmentID string, secretIDs []s
 }
 
 func FetchPhaseSecretsWithDynamic(tokenType, appToken, envID, host, path, keyDigest string, dynamic, lease bool, leaseTTL *int) ([]map[string]interface{}, error) {
-	reqURL := fmt.Sprintf("%s/service/secrets/", host)
-	req, err := http.NewRequest("GET", reqURL, nil)
+	body, err := FetchPhaseSecretsWithDynamicRaw(tokenType, appToken, envID, host, path, keyDigest, dynamic, lease, leaseTTL)
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header = ConstructHTTPHeaders(tokenType, appToken)
-	req.Header.Set("Environment", envID)
-	if path != "" {
-		req.Header.Set("Path", path)
-	}
-	if keyDigest != "" {
-		req.Header.Set("KeyDigest", keyDigest)
-	}
-	if dynamic {
-		req.Header.Set("dynamic", "true")
-	}
-	if lease {
-		req.Header.Set("lease", "true")
-	}
-	if leaseTTL != nil {
-		req.Header.Set("lease-ttl", fmt.Sprintf("%d", *leaseTTL))
-	}
-
-	body, err := makeRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
 	var secrets []map[string]interface{}
 	if err := json.Unmarshal(body, &secrets); err != nil {
 		return nil, fmt.Errorf("failed to decode secrets response: %w", err)

--- a/phase/offline.go
+++ b/phase/offline.go
@@ -1,0 +1,80 @@
+package phase
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/phasehq/golang-sdk/v2/phase/network"
+)
+
+// OfflineConfig controls offline caching behavior.
+// When set on a Phase instance, encrypted API responses are cached to CacheDir
+// and served from cache when the network is unavailable.
+type OfflineConfig struct {
+	CacheDir string // Root cache directory (e.g. ~/.phase/secrets/offline/{account_id})
+	Offline  bool   // When true, skip network entirely and serve from cache
+}
+
+// SetOfflineConfig enables offline caching on this Phase instance.
+func (p *Phase) SetOfflineConfig(cfg *OfflineConfig) {
+	p.offlineConfig = cfg
+}
+
+// pathHash returns a filesystem-safe SHA-256 hex digest for a cache key.
+func pathHash(envName, appName, appID, path string) string {
+	if path == "" {
+		path = "/"
+	}
+	raw := fmt.Sprintf("%s|%s|%s|%s", envName, appName, appID, path)
+	h := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(h[:])
+}
+
+// userDataCachePath returns the path for cached user data (AppKeyResponse).
+func userDataCachePath(cacheDir string) string {
+	return filepath.Join(cacheDir, "userdata.json")
+}
+
+// secretsCachePath returns the path for cached encrypted secrets.
+func secretsCachePath(cacheDir, envName, appName, appID, path string) string {
+	return filepath.Join(cacheDir, "secrets", pathHash(envName, appName, appID, path)+".json")
+}
+
+// cacheWrite atomically writes data to a file with 0600 permissions.
+func cacheWrite(fp string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(fp), 0700); err != nil {
+		return err
+	}
+	tmp := fp + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, fp); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// cacheRead reads a cached file.
+func cacheRead(fp string) ([]byte, error) {
+	return os.ReadFile(fp)
+}
+
+// isNetworkError returns true if the error indicates the server is unreachable
+// (DNS, connection, timeout, SSL) — not auth or API errors.
+func isNetworkError(err error) bool {
+	var netErr *network.NetworkError
+	var sslErr *network.SSLError
+	return errors.As(err, &netErr) || errors.As(err, &sslErr)
+}
+
+// offlineLog prints an offline-related message to stderr.
+func offlineLog(format string, args ...interface{}) {
+	log.Printf("[phase] "+format, args...)
+}

--- a/phase/phase.go
+++ b/phase/phase.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/phasehq/golang-sdk/v2/phase/crypto"
@@ -25,6 +26,7 @@ type Phase struct {
 	TokenType          string
 	IsServiceToken     bool
 	IsUserToken        bool
+	offlineConfig      *OfflineConfig
 }
 
 // Return when a secret key does not exist at the specified path.
@@ -270,18 +272,54 @@ func (p *Phase) Get(opts GetOptions) ([]SecretResult, error) {
 }
 
 // fetchSecrets fetches and decrypts secrets without resolving references.
+// When OfflineConfig is set, raw API responses are cached to disk on success
+// and served from cache when the network is unavailable.
 func (p *Phase) fetchSecrets(opts GetOptions) ([]SecretResult, error) {
-	resp, err := network.FetchPhaseUser(p.TokenType, p.AppToken, p.Host)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
+	cfg := p.offlineConfig
+	offline := cfg != nil && cfg.Offline
 
+	// --- Step 1: Get user data (from network or cache) ---
 	var userData misc.AppKeyResponse
-	if err := json.NewDecoder(resp.Body).Decode(&userData); err != nil {
+	var userDataBytes []byte
+
+	if offline {
+		// Offline mode: load from cache only
+		cached, err := cacheRead(userDataCachePath(cfg.CacheDir))
+		if err != nil {
+			return nil, fmt.Errorf("offline mode: no cached user data available: %w", err)
+		}
+		userDataBytes = cached
+	} else {
+		// Online: fetch from network
+		raw, err := network.FetchPhaseUserRaw(p.TokenType, p.AppToken, p.Host)
+		if err != nil {
+			if cfg != nil && isNetworkError(err) {
+				// Try cache fallback
+				cached, cacheErr := cacheRead(userDataCachePath(cfg.CacheDir))
+				if cacheErr == nil {
+					fmt.Fprintf(os.Stderr, "⚠ Network unavailable, using cached secrets. Set PHASE_OFFLINE=1 to skip network attempts\n")
+					userDataBytes = cached
+					offline = true // switch to offline for the rest of this call
+				} else {
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
+		} else {
+			userDataBytes = raw
+			// Cache user data on success
+			if cfg != nil {
+				_ = cacheWrite(userDataCachePath(cfg.CacheDir), raw)
+			}
+		}
+	}
+
+	if err := json.Unmarshal(userDataBytes, &userData); err != nil {
 		return nil, fmt.Errorf("failed to decode user data: %w", err)
 	}
 
+	// --- Step 2: Resolve app/env context ---
 	appName, _, envName, envID, publicKey, err := misc.PhaseGetContext(&userData, opts.AppName, opts.EnvName, opts.AppID)
 	if err != nil {
 		return nil, err
@@ -303,31 +341,72 @@ func (p *Phase) fetchSecrets(opts GetOptions) ([]SecretResult, error) {
 		return nil, fmt.Errorf("failed to generate env key pair: %w", err)
 	}
 
-	// Compute key digest for single-key lookups
+	// Compute key digest for single-key lookups (only when online — cache stores full env)
 	var keyDigest string
-	if len(opts.Keys) == 1 {
+	if !offline && len(opts.Keys) == 1 {
 		decryptedSalt, saltErr := p.Decrypt(envKey.WrappedSalt, userData.WrappedKeyShare)
 		if saltErr == nil {
 			keyDigest, _ = crypto.Blake2bDigest(opts.Keys[0], decryptedSalt)
 		}
 	}
 
-	// Fetch secrets
-	var secrets []map[string]interface{}
-	if opts.Dynamic {
-		secrets, err = network.FetchPhaseSecretsWithDynamic(p.TokenType, p.AppToken, envID, p.Host, opts.Path, keyDigest, true, opts.Lease, opts.LeaseTTL)
+	// --- Step 3: Get encrypted secrets (from network or cache) ---
+	var secretsBytes []byte
+
+	if offline {
+		cached, err := cacheRead(secretsCachePath(cfg.CacheDir, envName, appName, opts.AppID, opts.Path))
+		if err != nil {
+			return nil, fmt.Errorf("offline mode: no cached secrets for environment '%s': %w", envName, err)
+		}
+		secretsBytes = cached
 	} else {
-		secrets, err = network.FetchPhaseSecrets(p.TokenType, p.AppToken, envID, p.Host, opts.Path, keyDigest)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch secrets: %w", err)
+		var raw []byte
+		if opts.Dynamic {
+			raw, err = network.FetchPhaseSecretsWithDynamicRaw(p.TokenType, p.AppToken, envID, p.Host, opts.Path, keyDigest, true, opts.Lease, opts.LeaseTTL)
+		} else {
+			raw, err = network.FetchPhaseSecretsRaw(p.TokenType, p.AppToken, envID, p.Host, opts.Path, keyDigest)
+		}
+		if err != nil {
+			if cfg != nil && isNetworkError(err) {
+				cached, cacheErr := cacheRead(secretsCachePath(cfg.CacheDir, envName, appName, opts.AppID, opts.Path))
+				if cacheErr == nil {
+					fmt.Fprintf(os.Stderr, "⚠ Network unavailable, using cached secrets. Set PHASE_OFFLINE=1 to skip network attempts\n")
+					secretsBytes = cached
+					offline = true
+				} else {
+					return nil, fmt.Errorf("failed to fetch secrets: %w", err)
+				}
+			} else {
+				return nil, fmt.Errorf("failed to fetch secrets: %w", err)
+			}
+		} else {
+			secretsBytes = raw
+			// Cache secrets on success
+			if cfg != nil {
+				_ = cacheWrite(secretsCachePath(cfg.CacheDir, envName, appName, opts.AppID, opts.Path), raw)
+			}
+		}
 	}
 
+	var secrets []map[string]interface{}
+	if err := json.Unmarshal(secretsBytes, &secrets); err != nil {
+		return nil, fmt.Errorf("failed to decode secrets: %w", err)
+	}
+
+	// --- Step 4: Decrypt secrets (shared path for online and offline) ---
 	var results []SecretResult
 	for _, secret := range secrets {
 		// Handle dynamic secrets
 		secretType, _ := secret["type"].(string)
 		if secretType == "dynamic" {
+			if offline {
+				name, _ := secret["name"].(string)
+				if name == "" {
+					name = "unknown"
+				}
+				fmt.Fprintf(os.Stderr, "⚠ Offline mode: dynamic secret '%s' requires network access, skipping\n", name)
+				continue
+			}
 			dynamicResults := processDynamicSecret(secret, envPrivKey, publicKey, appName, envName, opts)
 			results = append(results, dynamicResults...)
 			continue
@@ -421,6 +500,9 @@ func (p *Phase) fetchSecrets(opts GetOptions) ([]SecretResult, error) {
 
 // CREATE SECRETS
 func (p *Phase) Create(opts CreateOptions) error {
+	if p.offlineConfig != nil && p.offlineConfig.Offline {
+		return fmt.Errorf("cannot create secrets in offline mode")
+	}
 	resp, err := network.FetchPhaseUser(p.TokenType, p.AppToken, p.Host)
 	if err != nil {
 		return err
@@ -506,6 +588,9 @@ func (p *Phase) Create(opts CreateOptions) error {
 
 // UPDATE SECRETS
 func (p *Phase) Update(opts UpdateOptions) error {
+	if p.offlineConfig != nil && p.offlineConfig.Offline {
+		return fmt.Errorf("cannot update secrets in offline mode")
+	}
 	resp, err := network.FetchPhaseUser(p.TokenType, p.AppToken, p.Host)
 	if err != nil {
 		return err
@@ -665,6 +750,9 @@ func (p *Phase) Update(opts UpdateOptions) error {
 
 // DELETE SECRETS
 func (p *Phase) Delete(opts DeleteOptions) ([]string, error) {
+	if p.offlineConfig != nil && p.offlineConfig.Offline {
+		return nil, fmt.Errorf("cannot delete secrets in offline mode")
+	}
 	resp, err := network.FetchPhaseUser(p.TokenType, p.AppToken, p.Host)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Add `OfflineConfig` to `Phase` struct for transparent caching of raw encrypted API responses
- Cache `FetchPhaseUser` and `FetchPhaseSecrets` raw JSON bytes to disk (no plaintext secrets)
- Auto-fallback to cache on network failure with stderr warning
- `OfflineConfig.Offline=true` skips network entirely, serves from cache
- Dynamic secrets skipped with warning when offline
- `Create`/`Update`/`Delete` return error in offline mode
- Existing `FetchPhaseSecrets`/`FetchPhaseSecretsWithDynamic` refactored to wrap Raw variants

## New SDK surface
- `OfflineConfig{CacheDir, Offline}` struct
- `Phase.SetOfflineConfig(cfg)` method
- `network.FetchPhaseUserRaw()`, `FetchPhaseSecretsRaw()`, `FetchPhaseSecretsWithDynamicRaw()` — raw byte variants

## Cache structure
\`\`\`
{CacheDir}/
  userdata.json                              # raw AppKeyResponse JSON (encrypted env keys)
  secrets/
    {sha256(envName|appName|appID|path)}.json # raw encrypted secrets array
\`\`\`

## Test plan
- [ ] SDK builds and passes vet
- [ ] CLI with local replace directive compiles and works
- [ ] Secrets cached as encrypted JSON (not plaintext)
- [ ] Network failure → auto-fallback to cache
- [ ] `Offline=true` → serves from cache without network
- [ ] Write operations error cleanly in offline mode