### PR TITLE
Retry-After parsing & strict reference resolution

### DIFF
--- a/phase/misc/const.go
+++ b/phase/misc/const.go
@@ -3,7 +3,7 @@ package misc
 import "regexp"
 
 const (
-	Version           = "2.3.0"
+	Version           = "2.4.0"
 	PhVersion         = "v1"
 	PhaseCloudAPIHost = "https://console.phase.dev"
 )

--- a/phase/network/errors.go
+++ b/phase/network/errors.go
@@ -1,6 +1,9 @@
 package network
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // NetworkError represents transport-level errors: DNS, connection refused, timeout.
 type NetworkError struct {
@@ -44,7 +47,9 @@ func (e *AuthorizationError) Error() string {
 }
 
 // RateLimitError represents HTTP 429 Too Many Requests.
-type RateLimitError struct{}
+type RateLimitError struct {
+	RetryAfter time.Duration
+}
 
 func (e *RateLimitError) Error() string {
 	return "rate limited"
@@ -54,6 +59,7 @@ func (e *RateLimitError) Error() string {
 type APIError struct {
 	StatusCode int
 	Detail     string
+	RetryAfter time.Duration
 }
 
 func (e *APIError) Error() string {

--- a/phase/network/network.go
+++ b/phase/network/network.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/user"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -128,22 +129,41 @@ func makeRequest(req *http.Request) ([]byte, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, formatHTTPError(resp.StatusCode, body)
+		return nil, formatHTTPError(resp.StatusCode, body, resp.Header)
 	}
 
 	return body, nil
 }
 
 // formatHTTPError creates a typed SDK error from an HTTP error response.
-func formatHTTPError(statusCode int, body []byte) error {
+func formatHTTPError(statusCode int, body []byte, headers http.Header) error {
 	switch statusCode {
 	case http.StatusForbidden:
 		return &AuthorizationError{Detail: extractErrorDetail(body)}
 	case http.StatusTooManyRequests:
-		return &RateLimitError{}
+		return &RateLimitError{RetryAfter: parseRetryAfter(headers)}
 	default:
-		return &APIError{StatusCode: statusCode, Detail: extractErrorDetail(body)}
+		return &APIError{StatusCode: statusCode, Detail: extractErrorDetail(body), RetryAfter: parseRetryAfter(headers)}
 	}
+}
+
+func parseRetryAfter(headers http.Header) time.Duration {
+	if headers == nil {
+		return 0
+	}
+	value := strings.TrimSpace(headers.Get("Retry-After"))
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if retryAt, err := http.ParseTime(value); err == nil {
+		if wait := time.Until(retryAt); wait > 0 {
+			return wait
+		}
+	}
+	return 0
 }
 
 // extractErrorDetail tries to extract an error message from a JSON response body.
@@ -175,7 +195,7 @@ func handleHTTPResponse(resp *http.Response) error {
 	}
 
 	body, _ := io.ReadAll(resp.Body)
-	return formatHTTPError(resp.StatusCode, body)
+	return formatHTTPError(resp.StatusCode, body, resp.Header)
 }
 
 func FetchPhaseUser(tokenType, appToken, host string) (*http.Response, error) {

--- a/phase/network/network_test.go
+++ b/phase/network/network_test.go
@@ -1,0 +1,34 @@
+package network
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestFormatHTTPErrorPreservesRetryAfter(t *testing.T) {
+	headers := http.Header{"Retry-After": []string{"7"}}
+
+	err := formatHTTPError(http.StatusTooManyRequests, nil, headers)
+	var rateErr *RateLimitError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("formatHTTPError() = %T, want *RateLimitError", err)
+	}
+	if rateErr.RetryAfter != 7*time.Second {
+		t.Fatalf("RetryAfter = %s, want 7s", rateErr.RetryAfter)
+	}
+}
+
+func TestFormatHTTPErrorPreservesRetryAfterForAPIError(t *testing.T) {
+	headers := http.Header{"Retry-After": []string{"3"}}
+
+	err := formatHTTPError(http.StatusServiceUnavailable, []byte(`{"error":"try later"}`), headers)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("formatHTTPError() = %T, want *APIError", err)
+	}
+	if apiErr.RetryAfter != 3*time.Second {
+		t.Fatalf("RetryAfter = %s, want 3s", apiErr.RetryAfter)
+	}
+}

--- a/phase/phase.go
+++ b/phase/phase.go
@@ -110,7 +110,7 @@ type GetOptions struct {
 	Lease                          bool
 	LeaseTTL                       *int
 	Raw                            bool // When true, return raw secret values without resolving references
-	FailOnReferenceResolutionError bool // When true, API errors while resolving references are returned instead of preserving raw refs.
+	FailOnReferenceResolutionError bool // When true, any failure to resolve a reference (fetch error or unresolved/missing reference) returns an error instead of preserving the raw ref. Default false preserves unresolved refs as-is.
 }
 
 // CREATE SECRETS

--- a/phase/phase.go
+++ b/phase/phase.go
@@ -100,16 +100,17 @@ type KeyValuePair struct {
 
 // GET SECRETS
 type GetOptions struct {
-	EnvName  string
-	AppName  string
-	AppID    string
-	Keys     []string
-	Tag      string
-	Path     string
-	Dynamic  bool
-	Lease    bool
-	LeaseTTL *int
-	Raw      bool // When true, return raw secret values without resolving references
+	EnvName                        string
+	AppName                        string
+	AppID                          string
+	Keys                           []string
+	Tag                            string
+	Path                           string
+	Dynamic                        bool
+	Lease                          bool
+	LeaseTTL                       *int
+	Raw                            bool // When true, return raw secret values without resolving references
+	FailOnReferenceResolutionError bool // When true, API errors while resolving references are returned instead of preserving raw refs.
 }
 
 // CREATE SECRETS
@@ -266,8 +267,11 @@ func (p *Phase) Get(opts GetOptions) ([]SecretResult, error) {
 			if secret.Value == "" {
 				continue
 			}
-			resolvedValue, err := ResolveAllSecrets(secret.Value, results, p, secret.Application, secret.Environment)
+			resolvedValue, err := resolveAllSecretsWithOptions(secret.Value, results, p, secret.Application, secret.Environment, opts.FailOnReferenceResolutionError)
 			if err != nil {
+				if opts.FailOnReferenceResolutionError {
+					return nil, fmt.Errorf("failed to resolve references in key %s: %w", secret.Key, err)
+				}
 				p.debugf("failed to resolve references in key %s: %v", secret.Key, err)
 				continue // Keep original unresolved value
 			}

--- a/phase/referencing.go
+++ b/phase/referencing.go
@@ -223,7 +223,14 @@ func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase
 				childVisited[k] = v
 			}
 			childVisited[canonical] = true
-			resolvedVal, err = resolveAllSecretsInternal(resolvedVal, allSecrets, p, app, env, childVisited, failOnFetchError)
+			// allSecrets holds only the originating app's in-memory secrets. Once we
+			// cross into a different app, drop it so that app's references resolve from
+			// the cache instead of being shadowed by the originating app's values.
+			childSecrets := allSecrets
+			if app != currentApp {
+				childSecrets = nil
+			}
+			resolvedVal, err = resolveAllSecretsInternal(resolvedVal, childSecrets, p, app, env, childVisited, failOnFetchError)
 			if err != nil {
 				return "", err
 			}

--- a/phase/referencing.go
+++ b/phase/referencing.go
@@ -131,11 +131,11 @@ func ResolveAllSecrets(value string, allSecrets []SecretResult, p *Phase, curren
 	return resolveAllSecretsInternal(value, allSecrets, p, currentApp, currentEnv, nil, false)
 }
 
-func resolveAllSecretsWithOptions(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string, failOnFetchError bool) (string, error) {
-	return resolveAllSecretsInternal(value, allSecrets, p, currentApp, currentEnv, nil, failOnFetchError)
+func resolveAllSecretsWithOptions(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string, failOnResolutionError bool) (string, error) {
+	return resolveAllSecretsInternal(value, allSecrets, p, currentApp, currentEnv, nil, failOnResolutionError)
 }
 
-func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string, visited map[string]bool, failOnFetchError bool) (string, error) {
+func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string, visited map[string]bool, failOnResolutionError bool) (string, error) {
 	if visited == nil {
 		visited = map[string]bool{}
 	}
@@ -170,7 +170,7 @@ func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase
 		combo := fmt.Sprintf("%s|%s|%s", app, env, path)
 		if !seen[combo] {
 			seen[combo] = true
-			if err := ensureCached(p, app, env, path); err != nil && failOnFetchError {
+			if err := ensureCached(p, app, env, path); err != nil && failOnResolutionError {
 				return "", fmt.Errorf("failed to fetch referenced secrets for app %q env %q path %q: %w", app, env, path, err)
 			}
 		}
@@ -210,6 +210,9 @@ func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase
 		}
 
 		if !found {
+			if failOnResolutionError {
+				return "", fmt.Errorf("reference ${%s} could not be resolved: key %q not found in app %q env %q path %q", ref, keyName, app, env, path)
+			}
 			// Keep original reference text
 			resolutions = append(resolutions, resolvedRef{fullRef: value[locs[i][0]:locs[i][1]], resolvedVal: value[locs[i][0]:locs[i][1]]})
 			continue
@@ -230,7 +233,7 @@ func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase
 			if app != currentApp {
 				childSecrets = nil
 			}
-			resolvedVal, err = resolveAllSecretsInternal(resolvedVal, childSecrets, p, app, env, childVisited, failOnFetchError)
+			resolvedVal, err = resolveAllSecretsInternal(resolvedVal, childSecrets, p, app, env, childVisited, failOnResolutionError)
 			if err != nil {
 				return "", err
 			}

--- a/phase/referencing.go
+++ b/phase/referencing.go
@@ -41,18 +41,18 @@ func normalizePath(path string) string {
 	return path
 }
 
-func ensureCached(p *Phase, appName, envName, path string) {
+func ensureCached(p *Phase, appName, envName, path string) error {
 	ck := cacheKey(appName, envName, path)
 
 	secretsCacheMu.RLock()
 	_, ok := secretsCache[ck]
 	secretsCacheMu.RUnlock()
 	if ok {
-		return
+		return nil
 	}
 
 	if p == nil {
-		return
+		return nil
 	}
 	fetched, err := p.fetchSecrets(GetOptions{
 		EnvName: envName,
@@ -60,7 +60,7 @@ func ensureCached(p *Phase, appName, envName, path string) {
 		Path:    normalizePath(path),
 	})
 	if err != nil {
-		return
+		return err
 	}
 	bucket := map[string]string{}
 	for _, s := range fetched {
@@ -70,6 +70,7 @@ func ensureCached(p *Phase, appName, envName, path string) {
 	secretsCacheMu.Lock()
 	secretsCache[ck] = bucket
 	secretsCacheMu.Unlock()
+	return nil
 }
 
 func getFromCache(appName, envName, path, keyName string) (string, bool) {
@@ -127,10 +128,14 @@ func parseReferenceContext(ref, currentApp, currentEnv string) (appName, envName
 
 // ResolveAllSecrets resolves all ${...} references in a value string.
 func ResolveAllSecrets(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string) (string, error) {
-	return resolveAllSecretsInternal(value, allSecrets, p, currentApp, currentEnv, nil)
+	return resolveAllSecretsInternal(value, allSecrets, p, currentApp, currentEnv, nil, false)
 }
 
-func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string, visited map[string]bool) (string, error) {
+func resolveAllSecretsWithOptions(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string, failOnFetchError bool) (string, error) {
+	return resolveAllSecretsInternal(value, allSecrets, p, currentApp, currentEnv, nil, failOnFetchError)
+}
+
+func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase, currentApp, currentEnv string, visited map[string]bool, failOnFetchError bool) (string, error) {
 	if visited == nil {
 		visited = map[string]bool{}
 	}
@@ -165,7 +170,9 @@ func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase
 		combo := fmt.Sprintf("%s|%s|%s", app, env, path)
 		if !seen[combo] {
 			seen[combo] = true
-			ensureCached(p, app, env, path)
+			if err := ensureCached(p, app, env, path); err != nil && failOnFetchError {
+				return "", fmt.Errorf("failed to fetch referenced secrets for app %q env %q path %q: %w", app, env, path, err)
+			}
 		}
 	}
 
@@ -216,7 +223,7 @@ func resolveAllSecretsInternal(value string, allSecrets []SecretResult, p *Phase
 				childVisited[k] = v
 			}
 			childVisited[canonical] = true
-			resolvedVal, err = resolveAllSecretsInternal(resolvedVal, allSecrets, p, app, env, childVisited)
+			resolvedVal, err = resolveAllSecretsInternal(resolvedVal, allSecrets, p, app, env, childVisited, failOnFetchError)
 			if err != nil {
 				return "", err
 			}

--- a/phase/referencing_test.go
+++ b/phase/referencing_test.go
@@ -224,3 +224,31 @@ func TestResolveAllSecrets_CrossAppInvalidRefReturnsError(t *testing.T) {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 }
+
+func TestResolveAllSecretsWithOptionsPreservesFetchFailureByDefault(t *testing.T) {
+	ResetSecretsCache()
+	t.Cleanup(ResetSecretsCache)
+
+	phase := &Phase{Host: "http://127.0.0.1:1", TokenType: "ServiceAccount", AppToken: "token"}
+	got, err := resolveAllSecretsWithOptions("value=${staging.KEY}", nil, phase, "app", "development", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "value=${staging.KEY}" {
+		t.Fatalf("got %q, want unresolved reference preserved", got)
+	}
+}
+
+func TestResolveAllSecretsWithOptionsFailsOnReferenceFetchError(t *testing.T) {
+	ResetSecretsCache()
+	t.Cleanup(ResetSecretsCache)
+
+	phase := &Phase{Host: "http://127.0.0.1:1", TokenType: "ServiceAccount", AppToken: "token"}
+	_, err := resolveAllSecretsWithOptions("value=${staging.KEY}", nil, phase, "app", "development", true)
+	if err == nil {
+		t.Fatal("expected reference fetch error")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch referenced secrets") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/phase/referencing_test.go
+++ b/phase/referencing_test.go
@@ -225,6 +225,34 @@ func TestResolveAllSecrets_CrossAppInvalidRefReturnsError(t *testing.T) {
 	}
 }
 
+func TestResolveAllSecrets_CrossAppNestedRefUsesReferencedAppSecrets(t *testing.T) {
+	ResetSecretsCache()
+	t.Cleanup(ResetSecretsCache)
+
+	// Seed the cache as if app "db" env "prod" path "/" had been fetched: its
+	// CONN nests a bare local ref ${HOST}, and db's own HOST is "db-host".
+	secretsCacheMu.Lock()
+	secretsCache["db|prod|/"] = map[string]string{
+		"CONN": "x@${HOST}",
+		"HOST": "db-host",
+	}
+	secretsCacheMu.Unlock()
+
+	// The originating app "web" has its OWN prod/HOST = "web-host" in memory.
+	webSecrets := []SecretResult{
+		{Application: "web", Environment: "prod", Path: "/", Key: "HOST", Value: "web-host"},
+	}
+
+	got, err := ResolveAllSecrets("${db::prod.CONN}", webSecrets, nil, "web", "prod")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The nested ${HOST} inside db's CONN must resolve to db's HOST, not web's.
+	if got != "x@db-host" {
+		t.Fatalf("got %q, want %q — originating app's HOST leaked into cross-app resolution", got, "x@db-host")
+	}
+}
+
 func TestResolveAllSecretsWithOptionsPreservesFetchFailureByDefault(t *testing.T) {
 	ResetSecretsCache()
 	t.Cleanup(ResetSecretsCache)

--- a/phase/referencing_test.go
+++ b/phase/referencing_test.go
@@ -280,3 +280,39 @@ func TestResolveAllSecretsWithOptionsFailsOnReferenceFetchError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestResolveAllSecretsWithOptionsFailsOnMissingReferencedKey(t *testing.T) {
+	ResetSecretsCache()
+	t.Cleanup(ResetSecretsCache)
+
+	// staging fetched successfully (bucket present) but has no KEY.
+	secretsCacheMu.Lock()
+	secretsCache["app|staging|/"] = map[string]string{"OTHER": "v"}
+	secretsCacheMu.Unlock()
+
+	_, err := resolveAllSecretsWithOptions("value=${staging.KEY}", nil, nil, "app", "development", true)
+	if err == nil {
+		t.Fatal("expected error for unresolved reference in fail mode")
+	}
+	if !strings.Contains(err.Error(), "could not be resolved") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveAllSecretsWithOptionsPreservesMissingReferencedKeyByDefault(t *testing.T) {
+	ResetSecretsCache()
+	t.Cleanup(ResetSecretsCache)
+
+	// staging fetched successfully (bucket present) but has no KEY.
+	secretsCacheMu.Lock()
+	secretsCache["app|staging|/"] = map[string]string{"OTHER": "v"}
+	secretsCacheMu.Unlock()
+
+	got, err := resolveAllSecretsWithOptions("value=${staging.KEY}", nil, nil, "app", "development", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "value=${staging.KEY}" {
+		t.Fatalf("got %q, want unresolved reference preserved", got)
+	}
+}


### PR DESCRIPTION
### Retry-After parsing & strict reference resolution

This PR adds two independent reliability improvements to the SDK, plus a related correctness fix found during review.

#### 1. Parse `Retry-After` on error responses

`RateLimitError` (HTTP 429) and `APIError` (other non-2xx) now carry a `RetryAfter time.Duration` field, populated from the response's `Retry-After` header. Both standard formats are supported:
- delta-seconds — `Retry-After: 7`
- HTTP-date — `Retry-After: Wed, 21 Oct 2025 07:28:00 GMT`

Returns `0` when the header is absent, malformed, or already in the past. This lets callers implement informed backoff instead of guessing.

#### 2. `FailOnReferenceResolutionError` option

Adds `GetOptions.FailOnReferenceResolutionError`. By default (`false`) behavior is unchanged: if a reference (`${app.env.PATH/KEY}`) can't be resolved — a fetch error, a missing/typo'd key, or an env that returns no secrets — the raw `${...}` reference is preserved and resolution continues silently. This keeps existing CLI/library flows working.

When set to `true`, **any** failure to resolve a reference returns an error to the caller instead of being swallowed, so consumers that require fully-resolved secrets (e.g. a Kubernetes operator rendering app config) fail fast rather than shipping an unresolved or incorrect placeholder. This covers both fetch failures and references that fetch fine but resolve to nothing.

The exported `ResolveAllSecrets` signature is unchanged — this is fully backward compatible.

#### 3. Fix: cross-app nested references resolved against the wrong app

A bare reference (e.g. `${HOST}`) nested inside a cross-app reference's value (`${db::prod.CONN}` where `CONN="x@${HOST}"`) was resolved against the **originating** app's in-memory secrets instead of the **referenced** app's secrets — recursion reassigns `currentApp` to the cross-app while the in-memory `secretsDict` still holds the originating app's values, so the `app == currentApp` guard matched the wrong set. The originating app's in-memory set is now dropped when recursion crosses into a different app, so those references resolve from the referenced app's cache.

No extra network calls: the referenced path is fetched once and the entire bucket (all keys at that path) is cached, so the nested same-path key is a cache hit. Covered by a new regression test.
